### PR TITLE
Fixes for nil values for empty inventory slots.

### DIFF
--- a/ItemLevelOverlay.lua
+++ b/ItemLevelOverlay.lua
@@ -24,7 +24,9 @@ local inventoryItemOverlayCache = {}
 local function getInventoryItemLevelFromInventorySlotName(inventorySlotName)
   local inventorySlotNumber = select(1, GetInventorySlotInfo(inventorySlotName))
   local inventoryItemLink   = GetInventoryItemLink("player", inventorySlotNumber)
-  return ItemUpgradeInfo:GetUpgradedItemLevel(inventoryItemLink)
+  if inventoryItemLink then
+    return ItemUpgradeInfo:GetUpgradedItemLevel(inventoryItemLink)
+  end
 end
 
 local function updateItemOverlay(overlayFrame, inventorySlotName, itemLevel)
@@ -46,9 +48,7 @@ local function updateItemOverlays(overlayFrame)
   for index, inventorySlotName in ipairs(inventorySlotNames) do
     local itemLevel = getInventoryItemLevelFromInventorySlotName(inventorySlotName)
 
-    if itemLevel then
-      updateItemOverlay(overlayFrame, inventorySlotName, itemLevel)
-    end
+    updateItemOverlay(overlayFrame, inventorySlotName, itemLevel)
   end
 end
 

--- a/ItemLevelOverlay.toc
+++ b/ItemLevelOverlay.toc
@@ -3,7 +3,7 @@
 ## Version: 0.2.0
 ## Notes: Displays your item levels overlaid on inventory slots in Character Info
 ## Author: Brandon Weiss
-## X-Website: https://github.com/brandonweiss/item_level_overlay
+## X-Website: https://github.com/brandonweiss/wow-item-level-overlay
 
 libs\LibStub\LibStub.lua
 libs\LibItemUpgradeInfo-1.0\LibItemUpgradeInfo-1.0.xml


### PR DESCRIPTION
Third time's a charm. I messed up PR#4 & #5 but I'm not touching anything until you check this one.

Line 27 - Added a check for when the inventoryItemLink is nil. The GetUpgradedItemLevel function gives an error on nil.

Line 51 - We should run the updateItemOverlay even when itemLevel is nil. That will clear the number from the inventory slot when nothing is equipped in that slot.

Thanks.
